### PR TITLE
switch when leaving

### DIFF
--- a/plugin/smartim.vim
+++ b/plugin/smartim.vim
@@ -19,5 +19,6 @@ function! SmartIM_SelectSaved()
     endif
 endfunction
 
+autocmd VimLeavePre * call SmartIM_SelectSaved()
 autocmd InsertLeave * call SmartIM_SelectDefault()
 autocmd InsertEnter * call SmartIM_SelectSaved()


### PR DESCRIPTION
* 退出 vim 的时候需要切换回原来的输入法。
* 我每次按 Esc 后，会有1秒延迟才切到普通模式，此时输入法才会切换。但如果按 Esc 后再按任意键，就会瞬间切换，所以把 Esc 映射成两次就能瞬间切换输入法了，不知道别人也有这个问题还是只有我这样，囧。。