### PR TITLE
Open VIM set IM to default

### DIFF
--- a/plugin/smartim.vim
+++ b/plugin/smartim.vim
@@ -102,6 +102,7 @@ endfunction
 augroup smartim
   autocmd!
   autocmd VimLeavePre * call Smartim_SelectDefault()
+  autocmd VimEnter    * call Smartim_SelectDefault()
   autocmd InsertLeave * call Smartim_SelectDefault()
   autocmd InsertEnter * call Smartim_SelectSaved()
 augroup end


### PR DESCRIPTION
When open vim，we should always set im to default