### PR TITLE
Opt: Pre-fetch current input method before im-select to reduce one ca…

### DIFF
--- a/im-select.m
+++ b/im-select.m
@@ -9,29 +9,26 @@
 #import <Carbon/Carbon.h>
 
 int main(int argc, const char * argv[]) {
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-
     int returnCode = 0;
-
-    if (argc > 1) {
-        NSString *imId = [NSString stringWithUTF8String:argv[1]];
-        NSDictionary *filter = [NSDictionary dictionaryWithObject:imId forKey:(NSString *)kTISPropertyInputSourceID];
-        CFArrayRef keyboards = TISCreateInputSourceList((CFDictionaryRef)filter, false);
-        if (keyboards) {
-            TISInputSourceRef selected = (TISInputSourceRef)CFArrayGetValueAtIndex(keyboards, 0);
-            returnCode = TISSelectInputSource(selected);
-            CFRelease(keyboards);
-        } else {
-            returnCode = 1;
-        }
-    } else {
+    @autoreleasepool {
         TISInputSourceRef current = TISCopyCurrentKeyboardInputSource();
-        NSString *sourceId = (NSString *)(TISGetInputSourceProperty(current, kTISPropertyInputSourceID));
+        NSString *sourceId = (__bridge NSString *)(TISGetInputSourceProperty(current, kTISPropertyInputSourceID));
         fprintf(stdout, "%s\n", [sourceId UTF8String]);
         CFRelease(current);
+        if (argc > 1) {
+            NSString *imId = [NSString stringWithUTF8String:argv[1]];
+            if (![sourceId isEqualToString:imId]) {
+                NSDictionary *filter = [NSDictionary dictionaryWithObject:imId forKey:(NSString *)kTISPropertyInputSourceID];
+                CFArrayRef keyboards = TISCreateInputSourceList((CFDictionaryRef)filter, false);
+                if (keyboards) {
+                    TISInputSourceRef selected = (TISInputSourceRef)CFArrayGetValueAtIndex(keyboards, 0);
+                    returnCode = TISSelectInputSource(selected);
+                    CFRelease(keyboards);
+                } else {
+                    returnCode = 1;
+                }
+            }
+        }
     }
-
-    [pool release];
-
     return returnCode;
 }

--- a/plugin/smartim.vim
+++ b/plugin/smartim.vim
@@ -55,7 +55,6 @@ call Smartim_start_debug()
 
 function! Smartim_GetInputMethodHandler(channel, msg)
   silent let b:saved_im = a:msg
-  silent call system(s:imselect_path . ' ' .g:smartim_default)
   call Smartim_debug_print('b:saved_im = ' . b:saved_im)
   call Smartim_debug_print('<<< Smartim_SelectDefault returned ' . v:shell_error)
 endfunction
@@ -68,10 +67,9 @@ function! Smartim_SelectDefault()
   endif
 
   if has('job')
-    call job_start([s:imselect_path], {'callback': 'Smartim_GetInputMethodHandler'})
+    call job_start([s:imselect_path, g:smartim_default], {'callback': 'Smartim_GetInputMethodHandler'})
   else
-    silent let b:saved_im = system(s:imselect_path)
-    silent call system(s:imselect_path . ' ' . g:smartim_default)
+    silent let b:saved_im = system(s:imselect_path . ' ' . g:smartim_default)
     call Smartim_debug_print('b:saved_im = ' . b:saved_im)
     call Smartim_debug_print('<<< Smartim_SelectDefault returned ' . v:shell_error)
   endif


### PR DESCRIPTION
The im-select flow has been optimized:

    It now pre-fetches and prints the current input method state.

    The actual input method switching logic is only executed if the desired input method does not match the current one.

This change effectively reduces the overall call overhead by one on every execution, as the necessary state information is now obtained as a prerequisite step.